### PR TITLE
Fix the directory path of the cached maven dependencies for the MacOS User

### DIFF
--- a/groupings/docker-compose.yml
+++ b/groupings/docker-compose.yml
@@ -19,7 +19,7 @@ services:
     volumes:
       - ${GROUPINGS_API_DIR}:/app/groupings # Hot reload directory
       - ${GROUPINGS_OVERRIDES}:/overrides
-      - /root/.m2:/root/.m2  # Cache Maven dependencies and hot reload updated dependencies
+      - ${HOME}/.m2:/root/.m2  # Cache Maven dependencies and hot reload updated dependencies
     environment:
       - SPRING_PROFILES_ACTIVE=dockerhost
       - spring.config.import=optional:file:/overrides/uh-groupings-api-overrides.properties, vault://cubbyhole/uhgroupings
@@ -38,7 +38,7 @@ services:
     volumes:
       - ${GROUPINGS_UI_DIR}:/app/groupings  # Hot reload directory
       - ${GROUPINGS_OVERRIDES}:/overrides
-      - /root/.m2:/root/.m2  # Cache Maven dependencies and hot reload updated dependencies
+      - ${HOME}/.m2:/root/.m2  # Cache Maven dependencies and hot reload updated dependencies
     environment:
       - SPRING_PROFILES_ACTIVE=dockerhost
       - SPRING_DEVTOOLS_RESTART_ENABLED=true


### PR DESCRIPTION
Fix the directory path of the maven dependencies cached for the MacOS User 

since /root is typically a directory that is restricted to the system administrator or root user, making it less accessible for regular users on the mac os. Need more setup to access it from docker. Therefore using HOME environment instead for avoiding extra OS setup.