### PR TITLE
Add the logic to unify the environment variables for the docker volume and remain one docker compose

### DIFF
--- a/groupings/README.md
+++ b/groupings/README.md
@@ -12,7 +12,8 @@ effect.
 ## Prerequisites
 
 1. The groupings API and UI projects must already be cloned to the localhost.
-2. The localhost Vault container must be running and contain the Groupings API password. See the vault README for details.
+2. Overrides folder must already be created on the path ( ${user.home}/.${user.name}-conf ) in the localhost
+3. The localhost Vault container must be running and contain the Groupings API password. See the vault README for details.
 
 # Installation
 

--- a/groupings/build.ps1
+++ b/groupings/build.ps1
@@ -68,6 +68,12 @@ function Set-PathVar {
     Set-Item -Path "Env:\$varName" -Value $varValue
 }
 
+# To match environment variables between MacOS and WindowsOS
+$env:HOME = $env:USERPROFILE
+Write-Host "Info: HOME environment variable is set to USERPROFILE"
+$env:USER = $env:USERNAME
+Write-Host "Info: USER environment variable is set to USERNAME"
+
 Write-Host "-------------------------------------------------------------------------"
 Write-Host "The Vault container must be running to deploy the Groupings containers."
 
@@ -79,10 +85,6 @@ Write-Host "the paths to your project directories. They are required to hot sync
 Write-Host "localhost source code changes into the containers."
 Write-Host "-------------------------------------------------------------------------"
 
-# Set GROUPINGS_OVERRIDES directory path.
-Write-Host "Provide the absolute path to the overrides file directory:"
-Set-PathVar "GROUPINGS_OVERRIDES"
-
 # Set GROUPINGS_API_DIR directory path.
 Write-Host "Provide the absolute paths to the Maven wrapper directories:"
 Set-MvnwVar "GROUPINGS_API_DIR"
@@ -93,6 +95,7 @@ Set-MvnwVar "GROUPINGS_UI_DIR"
 # Build/rebuild and deploy the images.
 Write-Host "Building and deploying the Grouping API container..."
 docker-compose up --build -d
+
 if ($LASTEXITCODE -eq 0) {
     Write-Host "Success: Groupings images built, stack and containers deployed"
 } else {

--- a/groupings/build.sh
+++ b/groupings/build.sh
@@ -79,10 +79,6 @@ echo "the paths to your project directories. They are required to hot sync"
 echo "localhost source code changes into the containers."
 echo "-------------------------------------------------------------------------"
 
-# Set GROUPINGS_OVERRIDES directory path.
-echo "Provide the absolute path to the overrides file directory:"
-set_path_var "GROUPINGS_OVERRIDES"
-
 # Set GROUPINGS_API_DIR directory path.
 Echo "Provide the absolute paths to the Maven wrapper directories:"
 set_mvnw_var "GROUPINGS_API_DIR"
@@ -93,6 +89,7 @@ set_mvnw_var "GROUPINGS_UI_DIR"
 # Build/rebuild and deploy the images.
 echo "Building and deploying the Grouping API container..."
 docker-compose up --build -d
+
 if [ $? -eq 0 ]; then
     echo "Success: Groupings images built, stack and containers deployed"
 else

--- a/groupings/docker-compose.yml
+++ b/groupings/docker-compose.yml
@@ -1,4 +1,4 @@
-# docker-compose.yml - UH Groupings - dev environment
+# docker-compose.yml - UH Groupings - docker dev environment
 
 # The build.sh script will invoke Docker to build this stack.
 
@@ -18,7 +18,7 @@ services:
       - "8081:8081"
     volumes:
       - ${GROUPINGS_API_DIR}:/app/groupings # Hot reload directory
-      - ${GROUPINGS_OVERRIDES}:/overrides
+      - ${HOME}/.${USER}-conf:/overrides
       - ${HOME}/.m2:/root/.m2  # Cache Maven dependencies and hot reload updated dependencies
     environment:
       - SPRING_PROFILES_ACTIVE=dockerhost
@@ -37,7 +37,7 @@ services:
       - "8080:8080"
     volumes:
       - ${GROUPINGS_UI_DIR}:/app/groupings  # Hot reload directory
-      - ${GROUPINGS_OVERRIDES}:/overrides
+      - ${HOME}/.${USER}-conf:/overrides
       - ${HOME}/.m2:/root/.m2  # Cache Maven dependencies and hot reload updated dependencies
     environment:
       - SPRING_PROFILES_ACTIVE=dockerhost

--- a/vault/build.ps1
+++ b/vault/build.ps1
@@ -2,11 +2,9 @@
 
 # build.ps1 - initialize for running vault.
 
-# Check if HOME environment variable is not set and set it to USERPROFILE if necessary.
-if (-not $env:HOME) {
-    $env:HOME = $env:USERPROFILE
-    Write-Host "Info: HOME environment variable was not set. Set it to USERPROFILE: $env:HOME"
-}
+$env:HOME = $env:USERPROFILE
+Write-Host "Info: HOME environment variable is set to USERPROFILE"
+
 
 # Create the necessary directories for vault data and configuration.
 $vaultDataDir = "$env:HOME\.vault\uhgroupings\data"


### PR DESCRIPTION
Add the logic to unify the environment variables for the docker volume and remain one docker compose
same as the way to map the environment variables in windows build bash file for vault

HOME environment variable is set to USERPROFILE
USER environment variable is set to USERNAME

