### PR TITLE
Remove devtools properties, Remove .m2 maven directory

### DIFF
--- a/groupings/build.ps1
+++ b/groupings/build.ps1
@@ -68,12 +68,6 @@ function Set-PathVar {
     Set-Item -Path "Env:\$varName" -Value $varValue
 }
 
-# To match environment variables between MacOS and WindowsOS
-$env:HOME = $env:USERPROFILE
-Write-Host "Info: HOME environment variable is set to USERPROFILE"
-$env:USER = $env:USERNAME
-Write-Host "Info: USER environment variable is set to USERNAME"
-
 Write-Host "-------------------------------------------------------------------------"
 Write-Host "The Vault container must be running to deploy the Groupings containers."
 

--- a/groupings/build.sh
+++ b/groupings/build.sh
@@ -79,6 +79,13 @@ echo "the paths to your project directories. They are required to hot sync"
 echo "localhost source code changes into the containers."
 echo "-------------------------------------------------------------------------"
 
+
+# To match environment variables between MacOS and WindowsOS
+export USERPROFILE=${HOME}
+echo "Info: USERPROFILE environment variable is set to HOME"
+export USERNAME=${USER}
+echo "Info: USERNAME environment variable is set to USER"
+
 # Set GROUPINGS_API_DIR directory path.
 Echo "Provide the absolute paths to the Maven wrapper directories:"
 set_mvnw_var "GROUPINGS_API_DIR"

--- a/groupings/docker-compose.yml
+++ b/groupings/docker-compose.yml
@@ -18,8 +18,7 @@ services:
       - "8081:8081"
     volumes:
       - ${GROUPINGS_API_DIR}:/app/groupings # Hot reload directory
-      - ${HOME}/.${USER}-conf:/overrides
-      - ${HOME}/.m2:/root/.m2  # Cache Maven dependencies and hot reload updated dependencies
+      - ${USERPROFILE}/.${USERNAME}-conf:/overrides
     environment:
       - SPRING_PROFILES_ACTIVE=dockerhost
       - spring.config.import=optional:file:/overrides/uh-groupings-api-overrides.properties, vault://cubbyhole/uhgroupings
@@ -37,11 +36,9 @@ services:
       - "8080:8080"
     volumes:
       - ${GROUPINGS_UI_DIR}:/app/groupings  # Hot reload directory
-      - ${HOME}/.${USER}-conf:/overrides
-      - ${HOME}/.m2:/root/.m2  # Cache Maven dependencies and hot reload updated dependencies
+      - ${USERPROFILE}/.${USERNAME}-conf:/overrides
     environment:
       - SPRING_PROFILES_ACTIVE=dockerhost
-      - SPRING_DEVTOOLS_RESTART_ENABLED=true
       - HEALTH_CHECK_URL="http://groupings-api:8081/uhgroupingsapi/api/groupings/v2.1/"
       - HEALTH_CHECK_INTERVAL=30   # Interval between retries in seconds
       - HEALTH_CHECK_TIMEOUT=10    # Timeout for each curl command in seconds


### PR DESCRIPTION
1. I Removed devtools properties of groupings-ui in docker-compose.yml.
Both API and UI projects still provided hot-reload and cache maven dependency after this change.
2. Change Major OS from Mac Os to Windows since most team members' os are Windows: this change will make MacOS to configure one more step when mac os user configure intellij with docker.
3. Remove .m2 maven directory for fully dockerizing. (will be downloading maven repository after building the image)