### PR TITLE
Implement dockerfile and docker-compose for react project

### DIFF
--- a/groupings/Dockerfile-ui-angular
+++ b/groupings/Dockerfile-ui-angular
@@ -1,4 +1,4 @@
-# Dockerfile-ui - UH Groupings UI - also enable hot updates
+# Dockerfile-ui-angular - UH Groupings UI - also enable hot updates
 
 # Use the pre-built base image.
 FROM groupings-base-image AS build

--- a/groupings/Dockerfile-ui-react
+++ b/groupings/Dockerfile-ui-react
@@ -1,0 +1,10 @@
+# Dockerfile-ui-react - UH Groupings UI - also enable hot updates from the editor in local machine
+
+# Use the node
+FROM node:21-alpine
+
+WORKDIR /app/groupings/ui
+
+# Install development dependencies when container starts
+# This allows for hot-reloading as the source code is mounted as a volume
+CMD ["sh", "-c", "npm install && npm run ${NODE_PROFILES_ACTIVE}"]

--- a/groupings/docker-compose-angular.yml
+++ b/groupings/docker-compose-angular.yml
@@ -1,6 +1,6 @@
-# docker-compose.yml - UH Groupings - docker dev environment
+# docker-compose.angular.yml - UH Groupings - docker dev environment for angular project
 
-# The build.sh script will invoke Docker to build this stack.
+# The build.sh or build.ps1 script will invoke Docker to build this stack.
 
 services:
   groupings-base:
@@ -27,9 +27,9 @@ services:
 #       spring.cloud.vault.token= xxx.xxxxxxxxxxxxxxxxxxxx
 #       The property above should be in the uh-groupings-api.override properties file of your local machine ({user.name}.conf directory)
 
-  groupings-ui:
+  groupings-ui-angular:
     build:
-      dockerfile: Dockerfile-ui
+      dockerfile: Dockerfile-ui-angular
     depends_on:
       - groupings-api
     ports:

--- a/groupings/docker-compose-react.yml
+++ b/groupings/docker-compose-react.yml
@@ -1,0 +1,47 @@
+# docker-compose.yml - UH Groupings - docker dev environment for next js project
+
+# The build.sh or build.ps1 script will invoke Docker to build this stack.
+
+services:
+  groupings-base:
+    build:
+      dockerfile: Dockerfile-base
+    image: groupings-base-image
+    command: /bin/sh -c "echo 'Groupings project base image - built using Rocky Linux 9.4, OpenJdk 17.'"
+
+  groupings-api:
+    build:
+      dockerfile: Dockerfile-api
+    depends_on:
+      - groupings-base
+    ports:
+      - "8081:8081"
+    volumes:
+      - ${GROUPINGS_API_DIR}:/app/groupings # Hot reload directory
+      - ${USERPROFILE}/.${USERNAME}-conf:/overrides
+    environment:
+      - SPRING_PROFILES_ACTIVE=dockerhost
+      - spring.config.import=optional:file:/overrides/uh-groupings-api-overrides.properties, vault://cubbyhole/uhgroupings
+      - spring.cloud.vault.enabled=true
+      - spring.cloud.vault.uri=http://host.docker.internal:8200
+#       spring.cloud.vault.token= xxx.xxxxxxxxxxxxxxxxxxxx
+#       The property above should be in the uh-groupings-api.override properties file of your local machine ({user.name}.conf directory)
+
+  groupings-ui-react:
+    build:
+      dockerfile: Dockerfile-ui-react
+    depends_on:
+      - groupings-api
+    ports:
+      - "8080:8080"
+    volumes:
+      - ${GROUPINGS_UI_DIR}:/app/groupings  # Hot reload directory
+      - ${USERPROFILE}/.${USERNAME}-conf:/overrides
+    environment:
+      - NODE_PROFILES_ACTIVE=dev
+      # Override NEXT_PUBLIC_API_2_1_BASE_URL for checking api handshake within docker containers
+      - NEXT_PUBLIC_API_2_1_BASE_URL=http://groupings-api:8081/uhgroupingsapi/api/groupings/v2.1
+      - HEALTH_CHECK_URL=http://groupings-api:8081/uhgroupingsapi/api/groupings/v2.1/
+      - HEALTH_CHECK_INTERVAL=30   # Interval between retries in seconds
+      - HEALTH_CHECK_TIMEOUT=10    # Timeout for each curl command in seconds
+      - HEALTH_CHECK_RETRIES=50     # Number of retries before giving up


### PR DESCRIPTION
Separate and add the docker files related to react

I maintain a bash script for each OS. It checks the UI directory provided by a member to determine which project it belongs to (Angular or React). Then, each compose file builds the API project with the matching UI project.

 Dev on the local machine will do hot reload of next js app running in docker container same as local dev.